### PR TITLE
Use new contact id based API to delete tags

### DIFF
--- a/lib/agilecrm-wrapper/contact.rb
+++ b/lib/agilecrm-wrapper/contact.rb
@@ -96,12 +96,15 @@ module AgileCRMWrapper
     end
 
     def delete_tags(tags)
-      email = get_property('email')
-      response = AgileCRMWrapper.connection.post(
-        'contacts/email/tags/delete', "email=#{email}&tags=#{tags}",
-        'content-type' => 'application/x-www-form-urlencoded'
+      response = AgileCRMWrapper.connection.put(
+        'contacts/delete/tags',
+        { id: id, tags: tags }
       )
-      self.tags = self.tags - tags if response.status == 204
+
+      if response.status == 200
+        self.tagsWithTime = response.body
+        self.tags = response.body.map { |t| t['tag'] }
+      end
     end
 
     def notes

--- a/spec/agilecrm-wrapper/contact_spec.rb
+++ b/spec/agilecrm-wrapper/contact_spec.rb
@@ -38,8 +38,8 @@ describe AgileCRMWrapper::Contact do
   describe '#delete_tags' do
     it 'removes the tags' do
       expect(
-        contact.delete_tags(contact.tags)
-      ).to eq []
+        contact.delete_tags(['sales'])
+      ).to eq ['rspec', 'new']
     end
   end
 

--- a/spec/fixtures/contacts/delete_tags.json
+++ b/spec/fixtures/contacts/delete_tags.json
@@ -1,0 +1,12 @@
+[{
+  "tag": "rspec",
+  "createdTime": 1412704793874,
+  "availableCount": 0,
+  "entity_type": "tag"
+},
+{
+  "tag": "new",
+  "createdTime": 1412704793874,
+  "availableCount": 0,
+  "entity_type": "tag"
+}]

--- a/spec/support/fake_agilecrm.rb
+++ b/spec/support/fake_agilecrm.rb
@@ -46,8 +46,8 @@ class FakeAgileCRM < Sinatra::Base
     json_response 200, 'contacts', 'updated_contact'
   end
 
-  post '/dev/api/contacts/email/tags/delete' do
-    status 204
+  put '/dev/api/contacts/delete/tags' do
+    json_response 200, 'contacts', 'delete_tags'
   end
 
   delete '/dev/api/contacts/:id' do


### PR DESCRIPTION
This change uses [the newly provided API call](https://github.com/agilecrm/rest-api#18-delete-tags-value-by-id) that works with the contact id instead of the email address. So this change will allow to delete tags for contacts that have no email address attached.

This does not change in the gem interface.
